### PR TITLE
Install pokerkit python package

### DIFF
--- a/telegram_poker_bot/deploy/Dockerfile.api
+++ b/telegram_poker_bot/deploy/Dockerfile.api
@@ -10,8 +10,9 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Install pokerkit first (as it's a dependency)
+COPY setup.py README.rst /app/
 COPY pokerkit/ /app/pokerkit/
-RUN pip install --no-cache-dir -e /app/pokerkit
+RUN pip install --no-cache-dir -e /app
 
 # Copy telegram_poker_bot requirements and filter out pokerkit line
 COPY telegram_poker_bot/requirements.txt /app/telegram_poker_bot/

--- a/telegram_poker_bot/deploy/Dockerfile.bot
+++ b/telegram_poker_bot/deploy/Dockerfile.bot
@@ -10,8 +10,9 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Install pokerkit first (as it's a dependency)
+COPY setup.py README.rst /app/
 COPY pokerkit/ /app/pokerkit/
-RUN pip install --no-cache-dir -e /app/pokerkit
+RUN pip install --no-cache-dir -e /app
 
 # Copy telegram_poker_bot requirements and filter out pokerkit line
 COPY telegram_poker_bot/requirements.txt /app/telegram_poker_bot/

--- a/telegram_poker_bot/deploy/Dockerfile.migrations
+++ b/telegram_poker_bot/deploy/Dockerfile.migrations
@@ -10,8 +10,9 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Install pokerkit first (as it's a dependency)
+COPY setup.py README.rst /app/
 COPY pokerkit/ /app/pokerkit/
-RUN pip install --no-cache-dir -e /app/pokerkit
+RUN pip install --no-cache-dir -e /app
 
 # Copy telegram_poker_bot requirements and filter out pokerkit line
 COPY telegram_poker_bot/requirements.txt /app/telegram_poker_bot/


### PR DESCRIPTION
Fix `pip install -e` error in Dockerfiles by correctly referencing the project root.

The previous setup attempted to install `/app/pokerkit` as an editable project, but `setup.py` was located in `/app`. This change ensures `setup.py` and `README.rst` are copied to `/app`, and `pip install -e` targets `/app`, allowing pip to find the necessary project metadata.

---
<a href="https://cursor.com/background-agent?bcId=bc-c91f7ffe-2a47-4b4a-8d6a-5bbdf7608915"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c91f7ffe-2a47-4b4a-8d6a-5bbdf7608915"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

