### PR TITLE
Fix docker build error for deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -48,6 +48,7 @@ docs/
 *.txt
 !requirements.txt
 !README.md
+!README.rst
 
 # Tests
 tests/


### PR DESCRIPTION
Allow Docker builds to copy `README.rst` by whitelisting it in `.dockerignore` to fix a missing-file error during migrations image build.

---
<a href="https://cursor.com/background-agent?bcId=bc-2119b78e-9a59-4aab-b3d4-97aac7c14632"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2119b78e-9a59-4aab-b3d4-97aac7c14632"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

