### PR TITLE
Update and deploy poker bot with dependency fix

### DIFF
--- a/telegram_poker_bot/requirements.txt
+++ b/telegram_poker_bot/requirements.txt
@@ -37,7 +37,7 @@ structlog==24.1.0
 pytest==7.4.4
 pytest-asyncio==0.23.3
 pytest-cov==4.1.0
-httpx==0.26.0
+httpx==0.25.2
 
 # Code Quality
 black==24.1.1


### PR DESCRIPTION
Pin `httpx` to version 0.25.2 to resolve a dependency conflict with `python-telegram-bot` during Docker image build.

---
<a href="https://cursor.com/background-agent?bcId=bc-6d2fd938-2c69-4c5a-b718-b4a87b697ce1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6d2fd938-2c69-4c5a-b718-b4a87b697ce1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

