### PR TITLE
Fix port allocation error for redis

### DIFF
--- a/telegram_poker_bot/deploy/.env.example
+++ b/telegram_poker_bot/deploy/.env.example
@@ -13,7 +13,8 @@ POSTGRES_PORT=5432
 # =============================================================================
 # REDIS CONFIGURATION
 # =============================================================================
-REDIS_PORT=6379
+# Set to 0 to let Docker choose a free host port and avoid conflicts with local Redis instances.
+REDIS_PORT=0
 REDIS_DB=0
 
 # =============================================================================

--- a/telegram_poker_bot/deploy/README.md
+++ b/telegram_poker_bot/deploy/README.md
@@ -92,7 +92,7 @@ docker-compose --profile nginx up -d
 ## Service Ports
 
 - **PostgreSQL**: 5432 (default)
-- **Redis**: 6379 (default)
+- **Redis**: dynamic by default (Docker picks a free host port). Set `REDIS_PORT` to pin it.
 - **API**: 8000 (default)
 - **Frontend**: 3000 (default)
 - **Nginx HTTP**: 80 (default)
@@ -100,7 +100,7 @@ docker-compose --profile nginx up -d
 
 You can override these in your `.env` file:
 - `POSTGRES_PORT`
-- `REDIS_PORT`
+- `REDIS_PORT` (set to `0` for automatic host port selection, or a specific port if you need it exposed)
 - `API_PORT`
 - `FRONTEND_PORT`
 - `NGINX_HTTP_PORT`

--- a/telegram_poker_bot/deploy/docker-compose.yml
+++ b/telegram_poker_bot/deploy/docker-compose.yml
@@ -27,8 +27,9 @@ services:
     image: redis:7-alpine
     container_name: pokerbot_redis
     command: redis-server --appendonly yes
+    # Default to 0 so Docker chooses a free host port when running alongside a local Redis instance.
     ports:
-      - "${REDIS_PORT:-6379}:6379"
+      - "${REDIS_PORT:-0}:6379"
     volumes:
       - redis_data:/data
     healthcheck:


### PR DESCRIPTION
Change Redis host port mapping to dynamic to avoid conflicts with local Redis instances.

---
<a href="https://cursor.com/background-agent?bcId=bc-58f8391c-fd85-4ccc-8cf7-a7f5e233b9f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-58f8391c-fd85-4ccc-8cf7-a7f5e233b9f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

