### PR TITLE
Avoid Redis port conflicts in docker-compose

### DIFF
--- a/telegram_poker_bot/deploy/README.md
+++ b/telegram_poker_bot/deploy/README.md
@@ -92,7 +92,7 @@ docker-compose --profile nginx up -d
 ## Service Ports
 
 - **PostgreSQL**: 5432 (default)
-- **Redis**: 6379 (default)
+- **Redis**: 6380 (default)
 - **API**: 8000 (default)
 - **Frontend**: 3000 (default)
 - **Nginx HTTP**: 80 (default)
@@ -105,6 +105,8 @@ You can override these in your `.env` file:
 - `FRONTEND_PORT`
 - `NGINX_HTTP_PORT`
 - `NGINX_HTTPS_PORT`
+
+> **Note:** The Redis service maps to host port `6380` by default to avoid clashing with a locally running Redis instance on `6379`. Adjust `REDIS_PORT` in your `.env` file if you prefer a different host port.
 
 ## Building from Source
 

--- a/telegram_poker_bot/deploy/docker-compose.yml
+++ b/telegram_poker_bot/deploy/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     container_name: pokerbot_redis
     command: redis-server --appendonly yes
     ports:
-      - "${REDIS_PORT:-6379}:6379"
+      - "${REDIS_PORT:-6380}:6379"
     volumes:
       - redis_data:/data
     healthcheck:


### PR DESCRIPTION
## Summary
- change the default host port mapping for Redis to 6380 to avoid conflicts when a local Redis instance is already using 6379
- document the new default port and explain how to override it via REDIS_PORT

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f6e6cded083278855a8dd389044bc)