### PR TITLE
Fix docker container config error

### DIFF
--- a/telegram_poker_bot/deploy/FIX_APPLIED.md
+++ b/telegram_poker_bot/deploy/FIX_APPLIED.md
@@ -1,0 +1,123 @@
+# Docker ContainerConfig Error - Fix Applied
+
+## What Happened
+
+You encountered a `KeyError: 'ContainerConfig'` error when running the `fix-docker-error.sh` script. The error occurred because:
+
+1. The script successfully rebuilt the Docker bot image (new hash: `c7fd7f10b6e25e2f...`)
+2. But Docker Compose still had internal metadata referencing the OLD deleted image (hash: `6c6d68ece6c49b0a...`)
+3. When trying to recreate the container, Docker Compose tried to inspect the deleted image
+4. This caused the `ContainerConfig` KeyError
+
+## Root Cause
+
+The original fix script had a flaw in its approach:
+- It manually removed containers and images
+- Then tried to use `docker-compose up -d` 
+- But Docker Compose's internal state still referenced the deleted image
+
+## What Was Fixed
+
+I updated the `fix-docker-error.sh` script with these critical changes:
+
+### Change 1: Use `docker-compose down` First
+```bash
+# OLD (lines 22-38): Manually stopped and removed container
+docker stop pokerbot_bot
+docker rm pokerbot_bot
+
+# NEW (line 24): Properly clean Docker Compose state
+docker-compose down
+```
+
+### Change 2: Use `--force-recreate` Flag
+```bash
+# OLD (line 74): Simple restart
+docker-compose up -d
+
+# NEW (line 70): Force complete recreation
+docker-compose up -d --force-recreate
+```
+
+### Change 3: Fixed Line Endings
+- Removed Windows CRLF line endings (which caused "required file not found" errors)
+- Ensured Unix LF line endings throughout
+
+## How to Use the Fixed Script
+
+From your Docker environment (where Docker is installed), run:
+
+```bash
+cd /Poker-Bot/telegram_poker_bot/deploy
+./fix-docker-error.sh
+```
+
+The script will now:
+1. ✓ Stop all services and remove containers cleanly (`docker-compose down`)
+2. ✓ Remove any orphaned bot containers
+3. ✓ Remove the corrupted bot image
+4. ✓ Prune dangling images
+5. ✓ Rebuild the bot image from scratch
+6. ✓ Start all services with forced recreation (no stale metadata)
+
+## Expected Output
+
+You should see:
+```
+[1/6] Stopping all services and removing containers...
+✓ Services stopped and containers removed
+[2/6] Removing any orphaned bot containers...
+✓ No orphaned containers found
+[3/6] Removing corrupted bot image...
+✓ Image removed: deploy_bot:latest
+[4/6] Pruning dangling images...
+✓ Dangling images pruned
+[5/6] Rebuilding bot image (this may take a few minutes)...
+✓ Bot image rebuilt successfully
+[6/6] Starting all services (forcing recreation)...
+✓ Services started successfully
+
+✓ Fix completed successfully!
+```
+
+## Verification
+
+After running the fixed script, verify everything works:
+
+```bash
+# Check all services are running
+docker-compose ps
+
+# Check bot logs
+docker-compose logs -f bot
+
+# Verify no errors
+docker-compose logs --tail=50 bot
+```
+
+## Why This Fix Works
+
+The updated script ensures:
+1. **Clean State**: `docker-compose down` removes ALL container metadata
+2. **No Orphans**: Explicitly removes any leftover containers
+3. **Fresh Build**: `--no-cache` ensures clean image rebuild
+4. **Complete Restart**: `--force-recreate` creates brand new containers without referencing old metadata
+
+This prevents Docker Compose from ever trying to inspect deleted images.
+
+## Files Modified
+
+1. `fix-docker-error.sh` - Updated with proper cleanup sequence
+2. `README-FIX-DOCKER-ERROR.md` - Updated documentation with detailed explanation
+
+## Support
+
+If you still encounter issues:
+1. Check the full documentation: `README-FIX-DOCKER-ERROR.md`
+2. Try the "Nuclear Option" (complete reset) from the README
+3. Verify Docker and docker-compose versions are compatible
+
+---
+
+**Status**: ✅ Fix ready to use
+**Date**: 2025-11-08


### PR DESCRIPTION
Fixes `KeyError: 'ContainerConfig'` in Docker Compose by ensuring proper cleanup and recreation of containers.

The original `fix-docker-error.sh` script manually removed containers and images, but `docker-compose up -d` would still attempt to use stale internal metadata from the *old* deleted image when recreating the container. This led to a `KeyError: 'ContainerConfig'` because the referenced image no longer existed. The updated script now uses `docker-compose down` for a complete cleanup of Docker Compose's state, followed by `--force-recreate` during `docker-compose up -d` to ensure containers are built from the new image without referencing old metadata.

---
<a href="https://cursor.com/background-agent?bcId=bc-be8d5fca-cd7e-4279-9b72-86400abdc887"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-be8d5fca-cd7e-4279-9b72-86400abdc887"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

