### PR TITLE
Fix repository root path for badge compute

### DIFF
--- a/deploy/lib/common.sh
+++ b/deploy/lib/common.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "${LIB_DIR}/.." && pwd)"
+REPO_ROOT="$(cd "${LIB_DIR}/../.." && pwd)"
 
 readonly LIB_DIR
 readonly REPO_ROOT


### PR DESCRIPTION
Correct `REPO_ROOT` calculation to point to the repository root, fixing deployment scripts failing due to `docker-compose.yml` not being found.

---
<a href="https://cursor.com/background-agent?bcId=bc-ef44c6a8-c1f7-4a20-96d9-32b48fccb598"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ef44c6a8-c1f7-4a20-96d9-32b48fccb598"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

