### PR TITLE
Fix docker dependency install space error

### DIFF
--- a/docker/app.Dockerfile
+++ b/docker/app.Dockerfile
@@ -21,9 +21,8 @@ RUN pip install --upgrade pip \
 WORKDIR /opt/app
 
 # Install Telegram Poker Bot runtime dependencies
-COPY telegram_poker_bot/requirements.txt /tmp/requirements.txt
-RUN grep -v "^-e" /tmp/requirements.txt > /tmp/runtime-requirements.txt \
-    && pip install --no-cache-dir -r /tmp/runtime-requirements.txt
+COPY telegram_poker_bot/requirements.runtime.txt /tmp/runtime-requirements.txt
+RUN pip install --no-cache-dir -r /tmp/runtime-requirements.txt
 
 # Copy application code
 COPY telegram_poker_bot/ /opt/app/

--- a/telegram_poker_bot/README.md
+++ b/telegram_poker_bot/README.md
@@ -60,6 +60,8 @@ telegram_poker_bot/
 # From repository root
 pip install -e .
 pip install -r telegram_poker_bot/requirements.txt
+# For runtime-only installs (no tests or code quality tooling):
+# pip install -r telegram_poker_bot/requirements.runtime.txt
 
 # Set up database
 createdb pokerbot

--- a/telegram_poker_bot/SETUP.md
+++ b/telegram_poker_bot/SETUP.md
@@ -28,6 +28,8 @@ cp .env.example .env.local
 # Back-end deps
 pip install -e .
 pip install -r telegram_poker_bot/requirements.txt
+# Runtime-only (omit tests/code quality tools):
+# pip install -r telegram_poker_bot/requirements.runtime.txt
 
 # Front-end deps
 cd telegram_poker_bot/frontend

--- a/telegram_poker_bot/requirements.runtime.txt
+++ b/telegram_poker_bot/requirements.runtime.txt
@@ -1,0 +1,31 @@
+# Telegram Bot
+python-telegram-bot==20.7
+aiogram==3.3.0
+
+# Web Framework
+fastapi==0.109.0
+uvicorn[standard]==0.27.0
+websockets==12.0
+python-multipart==0.0.6
+
+# Database
+sqlalchemy==2.0.25
+alembic==1.13.1
+asyncpg==0.29.0
+psycopg2-binary==2.9.9
+
+# Redis
+redis==5.0.1
+hiredis==2.2.3
+
+# Configuration
+python-dotenv==1.0.0
+pydantic==2.5.3
+pydantic-settings==2.1.0
+
+# Utilities
+python-dateutil==2.8.2
+pytz==2024.1
+
+# Logging
+structlog==24.1.0

--- a/telegram_poker_bot/requirements.txt
+++ b/telegram_poker_bot/requirements.txt
@@ -1,37 +1,8 @@
-# Telegram Bot
-python-telegram-bot==20.7
-aiogram==3.3.0
-
-# Web Framework
-fastapi==0.109.0
-uvicorn[standard]==0.27.0
-websockets==12.0
-python-multipart==0.0.6
-
-# Database
-sqlalchemy==2.0.25
-alembic==1.13.1
-asyncpg==0.29.0
-psycopg2-binary==2.9.9
-
-# Redis
-redis==5.0.1
-hiredis==2.2.3
-
-# Configuration
-python-dotenv==1.0.0
-pydantic==2.5.3
-pydantic-settings==2.1.0
+# Base runtime requirements
+-r requirements.runtime.txt
 
 # Poker Engine (local)
 -e ../pokerkit
-
-# Utilities
-python-dateutil==2.8.2
-pytz==2024.1
-
-# Logging
-structlog==24.1.0
 
 # Testing
 pytest==7.4.4


### PR DESCRIPTION
Separate runtime dependencies into a new file to reduce Docker image size and prevent 'No space left on device' errors during deployment.

The original `requirements.txt` included development and testing tools (e.g., `pytest`, `black`, `ruff`, `mypy`) which significantly increased the size of the Docker image during `pip install`, causing an `OSError: [Errno 28] No space left on device`. This change creates a `requirements.runtime.txt` with only essential production dependencies for the Docker build, while `requirements.txt` now includes the runtime dependencies and retains the development/testing tools for local development.

---
<a href="https://cursor.com/background-agent?bcId=bc-06545f94-0924-4612-baea-a70a96620651"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-06545f94-0924-4612-baea-a70a96620651"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

