### PR TITLE
Fix alembic ini configuration error

### DIFF
--- a/telegram_poker_bot/alembic.ini
+++ b/telegram_poker_bot/alembic.ini
@@ -1,5 +1,3 @@
-"""Alembic configuration."""
-
 [alembic]
 script_location = migrations
 prepend_sys_path = .


### PR DESCRIPTION
Remove the docstring from `alembic.ini` to fix a `MissingSectionHeaderError` during database migrations.

---
<a href="https://cursor.com/background-agent?bcId=bc-84d2f4f0-ec1c-4cbc-90f2-b017c0dd2e9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-84d2f4f0-ec1c-4cbc-90f2-b017c0dd2e9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

