### PR TITLE
Fix deployment errors and module not found

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 x-backend-build: &backend-build
   context: .
   dockerfile: docker/app.Dockerfile

--- a/telegram_poker_bot/migrations/env.py
+++ b/telegram_poker_bot/migrations/env.py
@@ -1,10 +1,16 @@
 """Alembic migration configuration."""
 
 from logging.config import fileConfig
+import sys
+from pathlib import Path
 
 from alembic import context
 from sqlalchemy import engine_from_config, pool
 from sqlalchemy.ext.asyncio import AsyncEngine
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
 
 from telegram_poker_bot.shared.config import get_settings
 from telegram_poker_bot.shared.models import Base


### PR DESCRIPTION
Fix `ModuleNotFoundError` during migrations and remove obsolete Docker Compose version attribute.

The `ModuleNotFoundError` occurred because the `telegram_poker_bot` package was not discoverable in the Python path when Alembic ran migrations inside the container. Prepending the project root to `sys.path` ensures the necessary modules can be imported. The `version` attribute in `docker-compose.yml` was removed as it is deprecated and caused a warning.

---
<a href="https://cursor.com/background-agent?bcId=bc-f4272232-3e74-4407-96f2-71cf9f01b836"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f4272232-3e74-4407-96f2-71cf9f01b836"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

