### PR TITLE
Fix deployment branch mismatch

### DIFF
--- a/deploy/first-deploy.sh
+++ b/deploy/first-deploy.sh
@@ -49,6 +49,7 @@ log_info "Repository root: ${REPO_ROOT}"
 ensure_command git
 ensure_command docker
 ensure_env_file
+load_env_file
 
 if [[ "${SKIP_PULL}" == "false" ]]; then
   log_info "Pulling latest upstream images (if any)"

--- a/deploy/lib/common.sh
+++ b/deploy/lib/common.sh
@@ -7,6 +7,7 @@ REPO_ROOT="$(cd "${LIB_DIR}/../.." && pwd)"
 
 readonly LIB_DIR
 readonly REPO_ROOT
+readonly ENV_FILE="${REPO_ROOT}/.env"
 
 COMPOSE_BIN=()
 COMPOSE_USES_PROJECT_DIR=false
@@ -55,10 +56,25 @@ ensure_command() {
 }
 
 ensure_env_file() {
-  local env_file="${REPO_ROOT}/.env"
-  if [[ ! -f "${env_file}" ]]; then
-    log_error "Missing ${env_file}. Copy .env.example and configure it before deploying."
+  if [[ ! -f "${ENV_FILE}" ]]; then
+    log_error "Missing ${ENV_FILE}. Copy .env.example and configure it before deploying."
     exit 1
+  fi
+}
+
+load_env_file() {
+  ensure_env_file
+
+  local allexport_was_on=false
+  if [[ "$(set -o | grep '^allexport')" =~ [[:space:]]on$ ]]; then
+    allexport_was_on=true
+  fi
+
+  set -a
+  # shellcheck disable=SC1090
+  source "${ENV_FILE}"
+  if [[ "${allexport_was_on}" == "false" ]]; then
+    set +a
   fi
 }
 

--- a/deploy/update.sh
+++ b/deploy/update.sh
@@ -48,6 +48,7 @@ done
 ensure_command git
 ensure_command docker
 ensure_env_file
+load_env_file
 check_worktree_clean
 
 REMOTE=${DEPLOY_GIT_REMOTE:-origin}


### PR DESCRIPTION
Source `.env` variables in deployment scripts to honor `DEPLOY_GIT_BRANCH` and `DEPLOY_GIT_REMOTE`.

The original `update.sh` and `first-deploy.sh` scripts were not loading the `.env` file in a way that exported its variables, causing `git fetch` and `git branch` commands to default to `origin/main` instead of the branch specified in `DEPLOY_GIT_BRANCH`. This PR introduces a `load_env_file` function to correctly source and export these variables, ensuring the deployment process uses the configured settings.

---
<a href="https://cursor.com/background-agent?bcId=bc-58f15fc5-445d-4974-9fbf-55db2b28ec50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-58f15fc5-445d-4974-9fbf-55db2b28ec50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

