### PR TITLE
Fix module not found error in migrations

### DIFF
--- a/docker/app.Dockerfile
+++ b/docker/app.Dockerfile
@@ -24,8 +24,8 @@ WORKDIR /opt/app
 COPY telegram_poker_bot/requirements.runtime.txt /tmp/runtime-requirements.txt
 RUN pip install --no-cache-dir -r /tmp/runtime-requirements.txt
 
-# Copy application code
-COPY telegram_poker_bot/ /opt/app/
+# Copy application code without flattening the package structure
+COPY telegram_poker_bot/ /opt/app/telegram_poker_bot/
 
 # Create unprivileged user
 RUN useradd --create-home --shell /usr/sbin/nologin poker \
@@ -34,6 +34,7 @@ RUN useradd --create-home --shell /usr/sbin/nologin poker \
 WORKDIR /opt/app
 USER poker
 
-ENV PYTHONPATH=/opt/app
+ENV PYTHONPATH=/opt/app \
+    ALEMBIC_CONFIG=/opt/app/telegram_poker_bot/alembic.ini
 
 # Default command is intentionally left blank; docker compose sets the service command.

--- a/telegram_poker_bot/migrations/env.py
+++ b/telegram_poker_bot/migrations/env.py
@@ -8,9 +8,13 @@ from alembic import context
 from sqlalchemy import engine_from_config, pool
 from sqlalchemy.ext.asyncio import AsyncEngine
 
-PROJECT_ROOT = Path(__file__).resolve().parents[2]
-if str(PROJECT_ROOT) not in sys.path:
-    sys.path.insert(0, str(PROJECT_ROOT))
+MIGRATIONS_DIR = Path(__file__).resolve().parent
+PACKAGE_ROOT = MIGRATIONS_DIR.parent
+REPO_ROOT = PACKAGE_ROOT.parent
+
+for path in (REPO_ROOT, PACKAGE_ROOT):
+    if str(path) not in sys.path:
+        sys.path.insert(0, str(path))
 
 from telegram_poker_bot.shared.config import get_settings
 from telegram_poker_bot.shared.models import Base


### PR DESCRIPTION
Fix `ModuleNotFoundError` during Alembic migrations by preserving the Python package structure in the Docker image and robustly configuring `sys.path` and `ALEMBIC_CONFIG`.

The `telegram_poker_bot` package was not correctly discoverable by Python in the container's migration environment, leading to a `ModuleNotFoundError`. This was caused by the Dockerfile flattening the package structure during copying and `env.py` not robustly adding the necessary paths to `sys.path`. The `ALEMBIC_CONFIG` environment variable was also missing, preventing Alembic from finding its configuration.

---
<a href="https://cursor.com/background-agent?bcId=bc-b9e862ed-2c10-466c-9a3b-e7e3a6b5a511"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b9e862ed-2c10-466c-9a3b-e7e3a6b5a511"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

