### PR TITLE
Ensure Alembic migrations run with packaged config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,14 @@ services:
     build: *backend-build
     image: pokerbot/backend:latest
     container_name: pokerbot_migrations
-    command: ["alembic", "upgrade", "head"]
+    command:
+      [
+        "alembic",
+        "-c",
+        "telegram_poker_bot/alembic.ini",
+        "upgrade",
+        "head"
+      ]
     env_file: *backend-env-file
     depends_on:
       postgres:


### PR DESCRIPTION
## Summary
- update the migrations service command so alembic uses the bundled configuration file
- avoid failures when running docker compose migrations by pointing to the correct script location

## Testing
- not run (explanation: docker compose not executed in CI environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69103343e35c83278144d91f2b694808)