### PR TITLE
Update and migrate pokerbot services

### DIFF
--- a/deploy/lib/common.sh
+++ b/deploy/lib/common.sh
@@ -99,9 +99,95 @@ compose() {
   fi
 }
 
+reset_postgres_password() {
+  log_info "Resetting PostgreSQL password to match .env configuration"
+  
+  load_env_file
+  
+  # Extract password from DATABASE_URL if available, otherwise use POSTGRES_PASSWORD
+  local new_password
+  if [[ -n "${DATABASE_URL:-}" ]]; then
+    # Extract password from postgresql+asyncpg://user:password@host:port/db
+    if [[ "${DATABASE_URL}" =~ postgresql\+?[^:]*://([^:]+):([^@]+)@ ]]; then
+      new_password="${BASH_REMATCH[2]}"
+      # URL decode the password (basic decoding for common cases)
+      # Note: This is a simple implementation. For full URL decoding, use a proper tool.
+      new_password="${new_password//%2F//}"
+      new_password="${new_password//%40/@}"
+      new_password="${new_password//%3A/:}"
+    else
+      log_error "Could not parse password from DATABASE_URL"
+      return 1
+    fi
+  else
+    new_password="${POSTGRES_PASSWORD:-changeme}"
+  fi
+  
+  local db_user="${POSTGRES_USER:-pokerbot}"
+  local postgres_password="${POSTGRES_PASSWORD:-changeme}"
+  
+  # Check if postgres container is running
+  if ! docker ps --format '{{.Names}}' | grep -q "^pokerbot_postgres$"; then
+    log_error "PostgreSQL container is not running"
+    return 1
+  fi
+  
+  # Reset password using docker exec (connect as postgres superuser)
+  # Try without password first (trust auth for local connections)
+  log_info "Updating password for user '${db_user}'"
+  
+  # Escape single quotes in password for SQL
+  local escaped_password="${new_password//\'/\'\'}"
+  
+  # Try connecting to postgres database (default database)
+  if docker exec pokerbot_postgres psql -U postgres -d postgres -c "ALTER USER ${db_user} WITH PASSWORD '${escaped_password}';" >/dev/null 2>&1; then
+    log_success "Password reset successfully"
+    return 0
+  fi
+  
+  # Try with POSTGRES_PASSWORD as PGPASSWORD
+  if PGPASSWORD="${postgres_password}" docker exec -e PGPASSWORD="${postgres_password}" pokerbot_postgres psql -U postgres -d postgres -c "ALTER USER ${db_user} WITH PASSWORD '${escaped_password}';" >/dev/null 2>&1; then
+    log_success "Password reset successfully"
+    return 0
+  fi
+  
+  # If both fail, provide manual instructions
+  log_error "Failed to reset password automatically. You may need to manually reset it."
+  log_info "Try running one of these commands:"
+  log_info "  docker exec -it pokerbot_postgres psql -U postgres -c \"ALTER USER ${db_user} WITH PASSWORD '${new_password}';\""
+  log_info "  Or if that requires a password:"
+  log_info "  PGPASSWORD=<current_postgres_password> docker exec -e PGPASSWORD=<current_postgres_password> pokerbot_postgres psql -U postgres -c \"ALTER USER ${db_user} WITH PASSWORD '${new_password}';\""
+  return 1
+}
+
 run_migrations() {
   log_info "Running database migrations"
-  compose --profile ops run --rm migrations
+  
+  # Try running migrations first
+  if compose --profile ops run --rm migrations; then
+    return 0
+  fi
+  
+  # If migrations failed, check if it's a password error
+  local exit_code=$?
+  if [[ ${exit_code} -ne 0 ]]; then
+    log_warn "Migrations failed. Checking if password reset is needed..."
+    
+    # Try to reset password and retry
+    if reset_postgres_password; then
+      log_info "Retrying migrations after password reset"
+      if compose --profile ops run --rm migrations; then
+        return 0
+      else
+        local retry_exit_code=$?
+        log_error "Migrations still failed after password reset (exit code: ${retry_exit_code})"
+        return ${retry_exit_code}
+      fi
+    else
+      log_error "Failed to reset password. Please check your database configuration."
+      return ${exit_code}
+    fi
+  fi
 }
 
 check_worktree_clean() {


### PR DESCRIPTION
Automatically reset PostgreSQL password and retry migrations to resolve `InvalidPasswordError` during deployment.

The `POSTGRES_PASSWORD` in `docker-compose.yml` only applies on initial PostgreSQL volume creation. If the database was previously initialized with a different password, subsequent `update.sh` runs would fail during migrations due to a password mismatch. This change introduces an automatic password reset mechanism that attempts to sync the PostgreSQL user's password with the `.env` configuration if migrations initially fail, then retries the migration.

---
<a href="https://cursor.com/background-agent?bcId=bc-7205da4a-17cc-485f-b1d0-6f85adaa69d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7205da4a-17cc-485f-b1d0-6f85adaa69d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

