### PR TITLE
Fix postgres password authentication

### DIFF
--- a/telegram_poker_bot/tests/test_config.py
+++ b/telegram_poker_bot/tests/test_config.py
@@ -45,3 +45,37 @@ def test_database_url_constructed_from_postgres_env(monkeypatch):
         settings.database_url
         == "postgresql+asyncpg://bot:p%40ss+word@db:6543/cards"
     )
+
+
+def test_postgres_password_loaded_from_file(monkeypatch, tmp_path):
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "token")
+    monkeypatch.setenv("PUBLIC_BASE_URL", "https://example.com")
+    monkeypatch.setenv("WEBAPP_SECRET", "secret")
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("POSTGRES_PASSWORD", raising=False)
+    monkeypatch.setenv("POSTGRES_USER", "bot")
+    monkeypatch.setenv("POSTGRES_DB", "cards")
+    monkeypatch.setenv("POSTGRES_HOST", "db")
+    password_file = tmp_path / "pgpass"
+    password_file.write_text("s3cret\n", encoding="utf-8")
+    monkeypatch.setenv("POSTGRES_PASSWORD_FILE", str(password_file))
+
+    settings = config.get_settings()
+
+    assert settings.postgres_password == "s3cret"
+    assert (
+        settings.database_url == "postgresql+asyncpg://bot:s3cret@db:5432/cards"
+    )
+
+
+def test_missing_postgres_password_file_raises(monkeypatch, tmp_path):
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "token")
+    monkeypatch.setenv("PUBLIC_BASE_URL", "https://example.com")
+    monkeypatch.setenv("WEBAPP_SECRET", "secret")
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("POSTGRES_PASSWORD", raising=False)
+    missing_file = tmp_path / "missing"
+    monkeypatch.setenv("POSTGRES_PASSWORD_FILE", str(missing_file))
+
+    with pytest.raises(ValueError, match="POSTGRES_PASSWORD_FILE"):
+        config.get_settings()


### PR DESCRIPTION
Add `POSTGRES_PASSWORD_FILE` support to allow database credentials to be read from a file, resolving `InvalidPasswordError` during Alembic migrations.

---
<a href="https://cursor.com/background-agent?bcId=bc-2f3b3a93-e6d7-4028-be4d-8743e74446fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2f3b3a93-e6d7-4028-be4d-8743e74446fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

