### PR TITLE
Run pokerbot database migrations

### DIFF
--- a/telegram_poker_bot/migrations/versions/001_initial_schema.py
+++ b/telegram_poker_bot/migrations/versions/001_initial_schema.py
@@ -1,6 +1,7 @@
 """Initial database migration - create all tables."""
 
-# revision identifiers
+# revision identifiers, used by Alembic.
+revision = "001_initial_schema"
 down_revision = None
 branch_labels = None
 depends_on = None


### PR DESCRIPTION
Add `revision` identifier to the initial schema migration to fix Alembic error.

Alembic failed to determine the revision ID from `001_initial_schema.py` because the `revision` variable was not declared, preventing database migrations from running.

---
<a href="https://cursor.com/background-agent?bcId=bc-0f12e645-9805-4909-9323-ee740e7ab760"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0f12e645-9805-4909-9323-ee740e7ab760"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

