### PR TITLE
Debug poker bot deployment errors

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,8 @@ ADMIN_CHAT_ID=your_admin_chat_id
 PUBLIC_BASE_URL=https://your-domain.com
 WEBHOOK_PATH=/telegram/webhook
 WEBHOOK_SECRET_TOKEN=your_webhook_secret
+WEBHOOK_BIND_HOST=0.0.0.0
+WEBHOOK_BIND_PORT=8443
 WEBAPP_SECRET=your_webapp_secret_here
 CORS_ORIGINS=https://your-domain.com
 

--- a/telegram_poker_bot/bot/main.py
+++ b/telegram_poker_bot/bot/main.py
@@ -91,6 +91,6 @@ if __name__ == "__main__":
     
     uvicorn.run(
         app,
-        host=settings.public_base_url.split("://")[1].split("/")[0] if "://" in settings.public_base_url else "0.0.0.0",
-        port=8443,
+        host=settings.webhook_bind_host,
+        port=settings.webhook_bind_port,
     )

--- a/telegram_poker_bot/shared/config.py
+++ b/telegram_poker_bot/shared/config.py
@@ -29,6 +29,8 @@ class Settings(BaseSettings):
     public_base_url: str
     webhook_path: str = "/telegram/webhook"
     webhook_secret_token: Optional[str] = None
+    webhook_bind_host: str = "0.0.0.0"
+    webhook_bind_port: int = 8443
 
     # Database
     database_url: Optional[str] = None


### PR DESCRIPTION
Introduce explicit webhook bind host and port settings to resolve `[Errno 99] cannot assign requested address` errors in containerized deployments.

The bot previously attempted to bind its webhook server to the `public_base_url`, which is an external address and not available for binding inside a Docker container. This change allows the bot to bind to an internal address (`0.0.0.0` by default) that is accessible within its container, preventing startup failures.

---
<a href="https://cursor.com/background-agent?bcId=bc-b913e11a-5db1-48b1-aaa0-9046315617ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b913e11a-5db1-48b1-aaa0-9046315617ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

