### PR TITLE
Update bot webhook for ssl domain

### DIFF
--- a/telegram_poker_bot/bot/main.py
+++ b/telegram_poker_bot/bot/main.py
@@ -1,12 +1,9 @@
 """Telegram bot service - webhook handler and command router."""
 
 import asyncio
-import hmac
-import hashlib
 from typing import Optional
 
 from fastapi import FastAPI, Request, Response, Header, HTTPException, status
-from fastapi.responses import JSONResponse
 from telegram import Update, Bot
 from telegram.ext import Application, CommandHandler, CallbackQueryHandler, MessageHandler, filters
 
@@ -25,6 +22,9 @@ from telegram_poker_bot.bot.webhook import verify_webhook_secret
 settings = get_settings()
 configure_logging()
 logger = get_logger(__name__)
+
+# Reusable Telegram Bot client
+bot_client = Bot(settings.telegram_bot_token)
 
 # Create FastAPI app for webhook
 app = FastAPI(title="Telegram Poker Bot Webhook")
@@ -51,7 +51,7 @@ async def telegram_webhook(
     
     # Parse update
     update_data = await request.json()
-    update = Update.de_json(update_data, Bot(settings.telegram_bot_token))
+    update = Update.de_json(update_data, bot_client)
     
     # Process update asynchronously
     asyncio.create_task(process_update(update))
@@ -84,6 +84,69 @@ async def process_update(update: Update):
 async def health_check():
     """Health check endpoint."""
     return {"status": "ok"}
+
+
+async def configure_telegram_webhook():
+    """Ensure Telegram webhook matches the configured PUBLIC_BASE_URL."""
+    webhook_url = settings.webhook_url
+    secret_token = settings.telegram_webhook_secret_token or settings.webhook_secret_token
+
+    if not secret_token:
+        logger.warning(
+            "Telegram webhook secret token is not configured; requests cannot be verified via secret token",
+            webhook_url=webhook_url,
+        )
+
+    kwargs = {"url": webhook_url}
+    if secret_token:
+        kwargs["secret_token"] = secret_token
+
+    webhook_info = None
+    try:
+        webhook_info = await bot_client.get_webhook_info()
+    except Exception as exc:  # pragma: no cover - network failure path
+        logger.warning("Unable to fetch current Telegram webhook info", error=str(exc))
+
+    needs_update = True
+    previous_url = None
+    if webhook_info:
+        previous_url = webhook_info.url or None
+        needs_update = webhook_info.url != webhook_url
+
+    if needs_update or secret_token:
+        try:
+            await bot_client.set_webhook(**kwargs)
+            logger.info(
+                "Telegram webhook configured",
+                webhook_url=webhook_url,
+                previous_url=previous_url,
+            )
+        except Exception as exc:
+            logger.error(
+                "Failed to configure Telegram webhook",
+                webhook_url=webhook_url,
+                error=str(exc),
+            )
+            raise
+    else:
+        logger.info("Telegram webhook already points to configured domain", webhook_url=webhook_url)
+
+
+@app.on_event("startup")
+async def on_startup():
+    """FastAPI startup hook to configure Telegram webhook."""
+    await configure_telegram_webhook()
+
+
+@app.on_event("shutdown")
+async def on_shutdown():
+    """FastAPI shutdown hook to close the Telegram bot session."""
+    close_method = getattr(bot_client, "close", None)
+    if callable(close_method):
+        try:
+            await close_method()  # type: ignore[misc]
+        except Exception as exc:  # pragma: no cover - best-effort cleanup
+            logger.warning("Failed to close Telegram bot session cleanly", error=str(exc))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Refactor bot webhook configuration to use the `PUBLIC_BASE_URL` from `.env`.

This change ensures the Telegram bot webhook is correctly set to the domain specified in the environment variables, resolving an issue where it was pointing to an incorrect domain. The bot's FastAPI application now automatically configures the webhook URL on startup based on the `PUBLIC_BASE_URL` and `WEBHOOK_PATH` settings.

---
<a href="https://cursor.com/background-agent?bcId=bc-817882a1-07cb-4139-b37b-7e6a479714a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-817882a1-07cb-4139-b37b-7e6a479714a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

