### PR TITLE
Fix port binding conflict on nginx

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,8 +68,8 @@ VITE_BOT_USERNAME=@your_bot_username
 # =============================================================================
 API_PORT=8000
 FRONTEND_PORT=3000
-NGINX_HTTP_PORT=80
-NGINX_HTTPS_PORT=443
+NGINX_HTTP_PORT=8080
+NGINX_HTTPS_PORT=8443
 NGINX_SSL_CERT_PATH=./deploy/nginx/ssl
 
 # =============================================================================

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -25,9 +25,11 @@ The scripts rely on these keys in `.env`:
 | --- | --- | --- |
 | `DEPLOY_GIT_REMOTE` | Git remote name used for updates | `origin` |
 | `DEPLOY_GIT_BRANCH` | Target branch for deploys | `main` |
+| `NGINX_HTTP_PORT` | Host port exposed for HTTP traffic | `8080` |
+| `NGINX_HTTPS_PORT` | Host port exposed for HTTPS traffic | `8443` |
 | `NGINX_SSL_CERT_PATH` | Host path containing TLS material mounted into the nginx container | `./deploy/nginx/ssl` |
 
-All application/service configuration is also read from `.env`. Review the file carefully before deploying.
+All application/service configuration is also read from `.env`. Review the file carefully before deploying. Override the Nginx port variables if you plan to expose the proxy on the conventional `80`/`443` pair or if another process already occupies the defaults.
 
 ## First-Time Deployment
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -112,23 +112,25 @@ services:
       - "${FRONTEND_PORT:-3000}:3000"
     restart: unless-stopped
 
-  nginx:
-    image: nginx:alpine
-    container_name: pokerbot_nginx
-    depends_on:
-      bot:
-        condition: service_started
-      api:
-        condition: service_started
-      frontend:
-        condition: service_started
-    ports:
-      - "${NGINX_HTTP_PORT:-80}:80"
-      - "${NGINX_HTTPS_PORT:-443}:443"
-    volumes:
-      - ./deploy/nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
-      - ${NGINX_SSL_CERT_PATH:-./deploy/nginx/ssl}:/etc/nginx/ssl:ro
-    restart: unless-stopped
+    nginx:
+      image: nginx:alpine
+      container_name: pokerbot_nginx
+      depends_on:
+        bot:
+          condition: service_started
+        api:
+          condition: service_started
+        frontend:
+          condition: service_started
+      profiles:
+        - nginx
+      ports:
+        - "${NGINX_HTTP_PORT:-8080}:80"
+        - "${NGINX_HTTPS_PORT:-8443}:443"
+      volumes:
+        - ./deploy/nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
+        - ${NGINX_SSL_CERT_PATH:-./deploy/nginx/ssl}:/etc/nginx/ssl:ro
+      restart: unless-stopped
 
 volumes:
   postgres_data:


### PR DESCRIPTION
Add an `nginx` compose profile and update default host ports to 8080/8443 to avoid "address already in use" errors.

The `nginx` service was previously always started, binding to ports 80 and 443, which are frequently occupied by other host services. This change makes the Nginx reverse proxy an opt-in component via a Docker Compose profile and uses higher default ports to reduce conflicts.

---
<a href="https://cursor.com/background-agent?bcId=bc-faa882e1-6220-4a1c-bbbd-146c3ad792a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-faa882e1-6220-4a1c-bbbd-146c3ad792a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

