### PR TITLE
Expose docker compose ports

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,6 +73,8 @@ services:
       redis:
         condition: service_healthy
     restart: unless-stopped
+    ports:
+      - "8443:8443"
 
   api:
     build: *backend-build
@@ -93,9 +95,9 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
-    ports:
-      - "${API_PORT:-8000}:8000"
     restart: unless-stopped
+    ports:
+      - "8000:8000"
 
   frontend:
     build:
@@ -106,9 +108,9 @@ services:
     environment:
       - VITE_API_URL=${VITE_API_URL:-http://localhost:8000}
       - VITE_BOT_USERNAME=${VITE_BOT_USERNAME:-@pokerbot}
-    ports:
-      - "${FRONTEND_PORT:-3000}:3000"
     restart: unless-stopped
+    ports:
+      - "3000:3000"
 
   nginx:
     image: nginx:alpine


### PR DESCRIPTION
Expose bot, API, and frontend services on fixed host ports in `docker-compose.yml` to simplify local development and ensure consistent port mappings.

---
<a href="https://cursor.com/background-agent?bcId=bc-c24d93a4-b190-4b09-9d5d-0d1505ac5e91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c24d93a4-b190-4b09-9d5d-0d1505ac5e91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

