### PR TITLE
Ignore update and deploy scripts in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,6 +140,9 @@ dmypy.json
 # Cython debug symbols
 cython_debug/
 
+# Local deploy helper scripts
+update
+first-deploy
 
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839


### PR DESCRIPTION
Add `update` and `first-deploy` to `.gitignore` to prevent local permission changes from being tracked.

---
<a href="https://cursor.com/background-agent?bcId=bc-9d86aa32-7e39-446e-a0b8-33c13d2f31ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9d86aa32-7e39-446e-a0b8-33c13d2f31ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

