### PR TITLE
Fix default Vite allowed hosts for local development

### DIFF
--- a/telegram_poker_bot/frontend/vite.config.ts
+++ b/telegram_poker_bot/frontend/vite.config.ts
@@ -5,10 +5,25 @@ import path from 'path'
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '')
-  const allowedHosts = (env.VITE_ALLOWED_HOSTS || 'poker.shahin8n.sbs')
+  const DEFAULT_ALLOWED_HOSTS = [
+    'poker.shahin8n.sbs',
+    'localhost',
+    '127.0.0.1',
+    '::1',
+  ]
+
+  const allowedHostsFromEnv = (env.VITE_ALLOWED_HOSTS || '')
     .split(',')
     .map((host) => host.trim())
     .filter(Boolean)
+
+  const allowedHosts = Array.from(
+    new Set(
+      allowedHostsFromEnv.length > 0
+        ? [...allowedHostsFromEnv, ...DEFAULT_ALLOWED_HOSTS]
+        : DEFAULT_ALLOWED_HOSTS,
+    ),
+  )
 
   return {
     plugins: [react()],


### PR DESCRIPTION
## Summary
- add localhost loopback addresses to the default Vite allowed hosts list
- merge any custom allowed hosts with the default list to keep local access functional

## Testing
- not run (not applicable)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912144b852083279b04f95fb3c25f39)