### PR TITLE
Fix indentation error in env.py

### DIFF
--- a/telegram_poker_bot/shared/config.py
+++ b/telegram_poker_bot/shared/config.py
@@ -162,14 +162,14 @@ class Settings(BaseSettings):
         base = self.public_base_url.rstrip("/")
         if not self.cors_origins:
             self.cors_origins = base
-          if not self.vite_api_url:
-              self.vite_api_url = f"{base}/api"
-          if not self.mini_app_base_url:
-              api_base = (self.vite_api_url or "").rstrip("/")
-              if api_base.endswith("/api"):
-                  self.mini_app_base_url = api_base[: -len("/api")]
-              else:
-                  self.mini_app_base_url = api_base or base
+        if not self.vite_api_url:
+            self.vite_api_url = f"{base}/api"
+        if not self.mini_app_base_url:
+            api_base = (self.vite_api_url or "").rstrip("/")
+            if api_base.endswith("/api"):
+                self.mini_app_base_url = api_base[: -len("/api")]
+            else:
+                self.mini_app_base_url = api_base or base
         return self
 
     @property


### PR DESCRIPTION
Fix indentation in `config.py` to resolve an `IndentationError` when running Alembic commands.

---
<a href="https://cursor.com/background-agent?bcId=bc-2d0c1a85-45b0-417d-afec-cdaecbfdd680"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2d0c1a85-45b0-417d-afec-cdaecbfdd680"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

