### PR TITLE
Fix group invite API client imports and restore service URL derivation

### DIFF
--- a/telegram_poker_bot/.gitignore
+++ b/telegram_poker_bot/.gitignore
@@ -20,6 +20,7 @@ wheels/
 .installed.cfg
 *.egg
 MANIFEST
+!frontend/src/lib/
 
 # Virtual Environment
 venv/

--- a/telegram_poker_bot/frontend/src/lib/apiClient.ts
+++ b/telegram_poker_bot/frontend/src/lib/apiClient.ts
@@ -1,0 +1,92 @@
+const API_BASE_URL = (import.meta.env.VITE_API_URL || '').replace(/\/$/, '')
+
+export class ApiError extends Error {
+  status: number
+  data: unknown
+
+  constructor(response: Response, data: unknown, message?: string) {
+    super(
+      message ||
+        (typeof data === 'object' && data && 'detail' in data
+          ? String((data as { detail: unknown }).detail)
+          : `Request failed with status ${response.status}`),
+    )
+    this.name = 'ApiError'
+    this.status = response.status
+    this.data = data
+  }
+}
+
+export interface ApiFetchOptions extends RequestInit {
+  initData?: string
+  json?: unknown
+}
+
+function resolveUrl(path: string) {
+  if (/^https?:/i.test(path)) {
+    return path
+  }
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`
+  return `${API_BASE_URL}${normalizedPath}`
+}
+
+function isFormLike(value: unknown): value is
+  | FormData
+  | URLSearchParams
+  | Blob
+  | ArrayBufferView
+  | ArrayBuffer
+  | ReadableStream
+  | string {
+  return (
+    value instanceof FormData ||
+    value instanceof URLSearchParams ||
+    value instanceof Blob ||
+    value instanceof ArrayBuffer ||
+    ArrayBuffer.isView(value as ArrayBufferView) ||
+    value instanceof ReadableStream ||
+    typeof value === 'string'
+  )
+}
+
+export async function apiFetch<T>(path: string, options: ApiFetchOptions = {}): Promise<T> {
+  const { initData, headers: inputHeaders, body, json, ...rest } = options
+  const headers = new Headers(inputHeaders)
+
+  if (initData) {
+    headers.set('X-Telegram-Init-Data', initData)
+  }
+
+  let requestBody = body
+
+  if (json !== undefined) {
+    headers.set('Content-Type', 'application/json')
+    requestBody = JSON.stringify(json)
+  } else if (body && typeof body === 'object' && !isFormLike(body)) {
+    headers.set('Content-Type', 'application/json')
+    requestBody = JSON.stringify(body)
+  }
+
+  const response = await fetch(resolveUrl(path), {
+    ...rest,
+    headers,
+    body: requestBody,
+  })
+
+  const text = await response.text()
+  let data: unknown = null
+
+  if (text) {
+    try {
+      data = JSON.parse(text)
+    } catch {
+      data = text
+    }
+  }
+
+  if (!response.ok) {
+    throw new ApiError(response, data)
+  }
+
+  return data as T
+}

--- a/telegram_poker_bot/shared/config.py
+++ b/telegram_poker_bot/shared/config.py
@@ -162,14 +162,14 @@ class Settings(BaseSettings):
         base = self.public_base_url.rstrip("/")
         if not self.cors_origins:
             self.cors_origins = base
-          if not self.vite_api_url:
-              self.vite_api_url = f"{base}/api"
-          if not self.mini_app_base_url:
-              api_base = (self.vite_api_url or "").rstrip("/")
-              if api_base.endswith("/api"):
-                  self.mini_app_base_url = api_base[: -len("/api")]
-              else:
-                  self.mini_app_base_url = api_base or base
+        if not self.vite_api_url:
+            self.vite_api_url = f"{base}/api"
+        if not self.mini_app_base_url:
+            api_base = (self.vite_api_url or "").rstrip("/")
+            if api_base.endswith("/api"):
+                self.mini_app_base_url = api_base[: -len("/api")]
+            else:
+                self.mini_app_base_url = api_base or base
         return self
 
     @property


### PR DESCRIPTION
## Summary
- add a shared frontend API client helper with Telegram init-data handling and JSON convenience helpers
- ensure the new helper directory is tracked by updating the frontend .gitignore override
- restore service URL derivation outside of the CORS guard so vite_api_url and mini_app_base_url are always computed

## Testing
- pytest telegram_poker_bot/tests/test_group_invite_flow.py *(fails: async_generator object has no attribute 'post' due to existing fixture setup)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69122c97d9dc8327865e6e7cd5e5cb00)