### PR TITLE
Avoid pulling private backend image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,7 @@ services:
   migrations:
     build: *backend-build
     image: pokerbot/backend:latest
+    pull_policy: never
     container_name: pokerbot_migrations
     command:
       [
@@ -64,6 +65,7 @@ services:
   bot:
     build: *backend-build
     image: pokerbot/backend:latest
+    pull_policy: never
     container_name: pokerbot_bot
     command: ["python", "-m", "telegram_poker_bot.bot.main"]
     env_file: *backend-env-file
@@ -79,6 +81,7 @@ services:
   api:
     build: *backend-build
     image: pokerbot/backend:latest
+    pull_policy: never
     container_name: pokerbot_api
     command:
       [


### PR DESCRIPTION
## Summary
- prevent docker compose from pulling the private pokerbot/backend image by setting the pull policy to never on backend services

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69122e62923c8327a7aa998b61e4a3c8)