### PR TITLE
Fix enum creation for group game invite migration

### DIFF
--- a/telegram_poker_bot/migrations/versions/002_group_game_invites.py
+++ b/telegram_poker_bot/migrations/versions/002_group_game_invites.py
@@ -8,15 +8,17 @@ depends_on = None
 
 from alembic import op
 import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
 
 
 def upgrade():
-    group_invite_status = sa.Enum(
+    group_invite_status = postgresql.ENUM(
         "PENDING",
         "READY",
         "CONSUMED",
         "EXPIRED",
         name="groupgameinvitestatus",
+        create_type=False,
     )
     group_invite_status.create(op.get_bind(), checkfirst=True)
 


### PR DESCRIPTION
## Summary
- update the group game invite migration to use the PostgreSQL-specific ENUM type
- prevent the migration from attempting to recreate the enum when the type already exists

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69122fe5baf08327911987c3670d5471)