### PR TITLE
Fix enum creation for group game invite migration

### DIFF
--- a/telegram_poker_bot/migrations/versions/002_group_game_invites.py
+++ b/telegram_poker_bot/migrations/versions/002_group_game_invites.py
@@ -18,7 +18,6 @@ def upgrade():
         "CONSUMED",
         "EXPIRED",
         name="groupgameinvitestatus",
-        create_type=False,
     )
     group_invite_status.create(op.get_bind(), checkfirst=True)
 


### PR DESCRIPTION
## Summary
- allow the group invite status enum type to be created on fresh databases by letting SQLAlchemy emit the CREATE TYPE statement

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691242ad800c83279dea2d18be28514f)