### PR TITLE
Fix link generation error

### DIFF
--- a/telegram_poker_bot/migrations/versions/003_lowercase_group_game_invite_status.py
+++ b/telegram_poker_bot/migrations/versions/003_lowercase_group_game_invite_status.py
@@ -1,0 +1,39 @@
+"""Normalize groupgameinvitestatus enum values to lowercase."""
+
+# revision identifiers, used by Alembic.
+revision = "003_lowercase_group_game_invite_status"
+down_revision = "002_group_game_invites"
+branch_labels = None
+depends_on = None
+
+from alembic import op
+
+
+def upgrade():
+    op.execute("ALTER TYPE groupgameinvitestatus RENAME TO groupgameinvitestatus_old")
+    op.execute(
+        "CREATE TYPE groupgameinvitestatus AS ENUM ('pending', 'ready', 'consumed', 'expired')"
+    )
+    op.execute("ALTER TABLE group_game_invites ALTER COLUMN status DROP DEFAULT")
+    op.execute(
+        "ALTER TABLE group_game_invites "
+        "ALTER COLUMN status TYPE groupgameinvitestatus "
+        "USING lower(status::text)::groupgameinvitestatus"
+    )
+    op.execute("ALTER TABLE group_game_invites ALTER COLUMN status SET DEFAULT 'pending'")
+    op.execute("DROP TYPE groupgameinvitestatus_old")
+
+
+def downgrade():
+    op.execute("ALTER TYPE groupgameinvitestatus RENAME TO groupgameinvitestatus_lower")
+    op.execute(
+        "CREATE TYPE groupgameinvitestatus AS ENUM ('PENDING', 'READY', 'CONSUMED', 'EXPIRED')"
+    )
+    op.execute("ALTER TABLE group_game_invites ALTER COLUMN status DROP DEFAULT")
+    op.execute(
+        "ALTER TABLE group_game_invites "
+        "ALTER COLUMN status TYPE groupgameinvitestatus "
+        "USING upper(status::text)::groupgameinvitestatus"
+    )
+    op.execute("ALTER TABLE group_game_invites ALTER COLUMN status SET DEFAULT 'PENDING'")
+    op.execute("DROP TYPE groupgameinvitestatus_lower")

--- a/telegram_poker_bot/shared/models.py
+++ b/telegram_poker_bot/shared/models.py
@@ -255,7 +255,13 @@ class GroupGameInvite(Base):
     game_id = Column(String(64), nullable=False, unique=True, index=True)
     creator_user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True)
     group_id = Column(Integer, ForeignKey("groups.id", ondelete="SET NULL"), nullable=True, index=True)
-    status = Column(Enum(GroupGameInviteStatus), nullable=False, default=GroupGameInviteStatus.PENDING, index=True)
+    status = Column(
+        Enum(GroupGameInviteStatus),
+        nullable=False,
+        default=GroupGameInviteStatus.PENDING,
+        server_default=GroupGameInviteStatus.PENDING.value,
+        index=True,
+    )
     deep_link = Column(String(255), nullable=False)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), onupdate=func.now())


### PR DESCRIPTION
Normalize `groupgameinvitestatus` enum values to lowercase to fix link generation errors caused by a mismatch between Postgres enum and ORM values.

---
<a href="https://cursor.com/background-agent?bcId=bc-59fa0557-153b-4df2-9fa5-1cbed47f7ecd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-59fa0557-153b-4df2-9fa5-1cbed47f7ecd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

