### PR TITLE
Fix alembic version update string truncation

### DIFF
--- a/telegram_poker_bot/migrations/versions/003_lowercase_group_game_invite_status.py
+++ b/telegram_poker_bot/migrations/versions/003_lowercase_group_game_invite_status.py
@@ -1,7 +1,7 @@
 """Normalize groupgameinvitestatus enum values to lowercase."""
 
 # revision identifiers, used by Alembic.
-revision = "003_lowercase_group_game_invite_status"
+revision = "003_lowercase_invite_status"
 down_revision = "002_group_game_invites"
 branch_labels = None
 depends_on = None


### PR DESCRIPTION
Shorten Alembic revision identifier to prevent `StringDataRightTruncationError` during migration.

The `alembic_version.version_num` column has a `character varying(32)` type. The previous revision identifier "003_lowercase_group_game_invite_status" exceeded this limit, causing the migration to fail. The new identifier "003_lowercase_invite_status" fits within the 32-character limit.

---
<a href="https://cursor.com/background-agent?bcId=bc-c95340a3-1efe-46b2-ba35-52c46eb23a48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c95340a3-1efe-46b2-ba35-52c46eb23a48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

